### PR TITLE
Remove precice internals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10.2)
 set(TARGET "6dof-rigid-body-solver")
 project(${TARGET} LANGUAGES CXX DESCRIPTION "6oF-rigid-body-solver")
 
+list (APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+find_package(Eigen3 3.2 REQUIRED)
 
 find_package(precice REQUIRED CONFIG)
 add_executable(
@@ -10,7 +12,7 @@ add_executable(
 	Structure0815.cpp
 	Tests.cpp)
 
-target_link_libraries(${TARGET} PRIVATE precice::precice)
+target_link_libraries(${TARGET} PRIVATE precice::precice Eigen3::Eigen)
 
 target_include_directories(${TARGET} PRIVATE $ENV{PRECICE_ROOT}/src)
 target_include_directories(${TARGET} PRIVATE $ENV{PRECICE_ROOT}/thirdparty/prettyprint/include)

--- a/Globals.hpp
+++ b/Globals.hpp
@@ -1,6 +1,8 @@
 #ifndef GLOBALS_HPP_
 #define GLOBALS_HPP_
 
+#include<iostream>
+
 /**
  * @brief For printing to the command line.
  *

--- a/Structure0815.cpp
+++ b/Structure0815.cpp
@@ -1,11 +1,11 @@
 #include "Structure0815.hpp"
 
+#include "math.hpp"
 #include "math/geometry.hpp"
 #include "math/math.hpp"
 
 using Eigen::Vector3d;
 using Eigen::VectorXd;
-
 
 namespace {
     constexpr const char * CSV_TIMESTEPS = "Timesteps";
@@ -208,7 +208,7 @@ void Structure0815::computeCharacteristics(
       double area = geometry::triangleArea(zero, coords0, coords1);
       area        = std::abs(area); // since it comes out signed from cross-prod
       totalVolume += area;
-      if (not precice::math::equals(area, 0.0)) {
+      if (not math::isZero(area)) {
         centerOfGravity += (coords0 + coords1) * area / 3.0;
       }
     }
@@ -241,7 +241,7 @@ void Structure0815::computeCharacteristics(
       double volume = crossVec.dot(vec03) / 6.0;
       volume        = std::abs(volume);
       totalVolume += volume;
-      if (not precice::math::equals(volume, 0.0)) {
+      if (not math::isZero(volume)) {
         centerOfGravity += (coords0 + coords1 + coords2) * volume / 4.0;
       }
     }

--- a/Structure0815.cpp
+++ b/Structure0815.cpp
@@ -1,8 +1,7 @@
 #include "Structure0815.hpp"
 
 #include "math.hpp"
-#include "math/geometry.hpp"
-#include "math/math.hpp"
+#include <cassert>
 
 using Eigen::Vector3d;
 using Eigen::VectorXd;
@@ -205,7 +204,7 @@ void Structure0815::computeCharacteristics(
         coords1[i] = _vertices[_faces[index + 1] * _dim + i];
         coords1[i] += _displacements[_faces[index + 1] * _dim + i];
       }
-      double area = geometry::triangleArea(zero, coords0, coords1);
+      double area = math::triangleArea(zero, coords0, coords1);
       area        = std::abs(area); // since it comes out signed from cross-prod
       totalVolume += area;
       if (not math::isZero(area)) {
@@ -213,7 +212,7 @@ void Structure0815::computeCharacteristics(
       }
     }
   } else {
-    assertion(_dim == 3, _dim);
+    assert(_dim == 3);
     VectorXd coords0(zero);
     VectorXd coords1(zero);
     VectorXd coords2(zero);

--- a/Structure0815.cpp
+++ b/Structure0815.cpp
@@ -6,17 +6,21 @@
 using Eigen::Vector3d;
 using Eigen::VectorXd;
 
+
+namespace {
+    constexpr const char * CSV_TIMESTEPS = "Timesteps";
+    constexpr const char * CSV_TIME = "Time";
+    constexpr const char * CSV_CENTEROFGRAVITY = "Center-of-gravity";
+    constexpr const char * CSV_TOTALMASS = "Total mass";
+    constexpr const char * CSV_TOTALVOLUME = "Total volume";
+};
+
 Structure0815::Structure0815(
     int                   dim,
     double                density,
     const VectorXd &      gravity,
     const VectorXd &      vertices,
-    const Eigen::VectorXi faces)
-    : TIMESTEPS("Timesteps"),
-      TIME("Time"),
-      CENTEROFGRAVITY("Center-of-gravity"),
-      TOTALMASS("Total mass"),
-      TOTALVOLUME("Total volume"),
+    const Eigen::VectorXi faces):
       _dim(dim),
       _density(density),
       _gravity(gravity),
@@ -45,28 +49,10 @@ Structure0815::Structure0815(
   STRUCTURE_INFO("Total mass: " << _totalMass);
   STRUCTURE_INFO("Total volume: " << totalVolume);
 
-  _statisticsWriter.addData(TIMESTEPS, precice::io::TXTTableWriter::INT);
-  _statisticsWriter.addData(TIME, precice::io::TXTTableWriter::DOUBLE);
-  if (dim == 2) {
-    _statisticsWriter.addData(CENTEROFGRAVITY, precice::io::TXTTableWriter::VECTOR2D);
-  } else {
-    _statisticsWriter.addData(CENTEROFGRAVITY, precice::io::TXTTableWriter::VECTOR3D);
-  }
-  _statisticsWriter.addData(TOTALMASS, precice::io::TXTTableWriter::DOUBLE);
-  _statisticsWriter.addData(TOTALVOLUME, precice::io::TXTTableWriter::DOUBLE);
-
-  _statisticsWriter.writeData(TIMESTEPS, _timesteps);
-  _statisticsWriter.writeData(TIME, _time);
-  if (dim == 2) {
-    Eigen::Vector2d centerOfGravity(_centerOfGravity);
-    _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity);
-  } else {
-    assertion(_dim == 3, _dim);
-    Eigen::Vector3d centerOfGravity(_centerOfGravity);
-    _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity);
-  }
-  _statisticsWriter.writeData(TOTALMASS, _totalMass);
-  _statisticsWriter.writeData(TOTALVOLUME, totalVolume);
+  // Write CSV header
+  _statisticsWriter << CSV_TIMESTEPS <<',' << CSV_TIME << ',' << CSV_CENTEROFGRAVITY << ',' << CSV_TOTALMASS << ',' << CSV_TOTALVOLUME << '\n';
+  // Write inital state
+  _statisticsWriter << _timesteps << ',' << _time << ',' << _centerOfGravity << ',' << _totalMass << ',' << totalVolume << '\n' << std::flush;
 }
 
 void Structure0815::fixPoint(
@@ -194,18 +180,8 @@ void Structure0815::timestep(double dt)
     STRUCTURE_INFO("Total volume delta: " << _totalMass / _density - totalVolume);
   }
 
-  _statisticsWriter.writeData(TIMESTEPS, _timesteps);
-  _statisticsWriter.writeData(TIME, _time);
-  if (_dim == 2) {
-    Eigen::Vector2d centerOfGravity2D(centerOfGravity);
-    _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity2D);
-  } else {
-    assertion(_dim == 3, _dim);
-    Eigen::Vector3d centerOfGravity3D(centerOfGravity);
-    _statisticsWriter.writeData(CENTEROFGRAVITY, centerOfGravity3D);
-  }
-  _statisticsWriter.writeData(TOTALMASS, totalMass);
-  _statisticsWriter.writeData(TOTALVOLUME, totalVolume);
+  // Write statistics
+  _statisticsWriter << _timesteps << ',' << _time << ',' << centerOfGravity << ',' << totalMass << ',' << totalVolume << '\n';
 }
 
 void Structure0815::computeCharacteristics(

--- a/Structure0815.hpp
+++ b/Structure0815.hpp
@@ -1,10 +1,10 @@
 #ifndef STRUCTURE0815_HPP_
 #define STRUCTURE0815_HPP_
 
-#include "Globals.hpp"
-#include "precice/SolverInterface.hpp"
-#include "utils/Dimensions.hpp"
 #include <fstream>
+#include <Eigen/Core>
+
+#include "Globals.hpp"
 
 using Eigen::VectorXd;
 
@@ -113,7 +113,7 @@ private:
   bool                                   _fixed;
   VectorXd                               _fixture;
   bool                                   _fixedCharacteristics;
-  std::fostream                          _statisticsWriter;
+  std::ofstream                          _statisticsWriter;
 
   /**
    * @brief Computes the center of gravity, total mass and total volume.

--- a/Structure0815.hpp
+++ b/Structure0815.hpp
@@ -2,9 +2,9 @@
 #define STRUCTURE0815_HPP_
 
 #include "Globals.hpp"
-#include "io/TXTTableWriter.hpp"
 #include "precice/SolverInterface.hpp"
 #include "utils/Dimensions.hpp"
+#include <fstream>
 
 using Eigen::VectorXd;
 
@@ -93,13 +93,6 @@ public:
   }
 
 private:
-  // String constants for statistics writer entries
-  const std::string TIMESTEPS;
-  const std::string TIME;
-  const std::string CENTEROFGRAVITY;
-  const std::string TOTALMASS;
-  const std::string TOTALVOLUME;
-
   int                                    _dim;
   double                                 _density;
   VectorXd                               _gravity;
@@ -120,7 +113,7 @@ private:
   bool                                   _fixed;
   VectorXd                               _fixture;
   bool                                   _fixedCharacteristics;
-  precice::io::TXTTableWriter            _statisticsWriter;
+  std::fostream                          _statisticsWriter;
 
   /**
    * @brief Computes the center of gravity, total mass and total volume.

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -1,7 +1,8 @@
+#include<iostream>
+
 #include "Tests.hpp"
 #include "Globals.hpp"
 #include "Structure0815.hpp"
-#include "math/math.hpp"
 
 using precice::math::equals;
 

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -1,10 +1,11 @@
 #include<iostream>
 
+#include "math.hpp"
 #include "Tests.hpp"
 #include "Globals.hpp"
 #include "Structure0815.hpp"
 
-using precice::math::equals;
+using math::isEqual;
 
 #define validate(booleanExpr, msg)                                          \
   if (!(booleanExpr)) {                                                     \
@@ -57,24 +58,24 @@ void Tests::test2D()
   validate(velDeltas.size() == 8, velDeltas.size());
 
   expected.setConstant(0.0);
-  validate(equals(forces, expected), forces);
-  validate(equals(displacements, expected), displacements);
-  validate(equals(velocities, expected), velocities);
-  validate(equals(displDeltas, expected), displDeltas);
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(forces, expected), forces);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   validate(structure.getCenterOfGravity().size() == 2, structure.getCenterOfGravity().size());
-  validate(equals(structure.getCenterOfGravity(), Vector2d(0.5, 0.5)),
+  validate(isEqual(structure.getCenterOfGravity(), Vector2d(0.5, 0.5)),
            structure.getCenterOfGravity());
 
   double dt = 0.0;
   structure.iterate(dt);
 
-  validate(equals(forces, expected), forces);
-  validate(equals(displacements, expected), displacements);
-  validate(equals(velocities, expected), velocities);
-  validate(equals(displDeltas, expected), displDeltas);
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(forces, expected), forces);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << 1.0, 0.0,
       1.0, 0.0,
@@ -85,22 +86,22 @@ void Tests::test2D()
   structure.iterate(dt);
 
   expected = forces;
-  validate(equals(forces, expected), forces);
+  validate(isEqual(forces, expected), forces);
   expected << 4.0, 0.0,
       4.0, 0.0,
       4.0, 0.0,
       4.0, 0.0;
-  validate(equals(displacements, expected), displacements);
-  validate(equals(velocities, expected), velocities);
-  validate(equals(displDeltas, expected), displDeltas);
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
 
-  validate(equals(displacements, expected), displacements);
-  validate(equals(velocities, expected), velocities);
-  validate(equals(displDeltas, expected), displDeltas);
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << 0.0, 1.0,
       0.0, 1.0,
@@ -112,22 +113,22 @@ void Tests::test2D()
       8.0, 4.0,
       8.0, 4.0,
       8.0, 4.0;
-  validate(equals(displacements, expected), displacements);
+  validate(isEqual(displacements, expected), displacements);
   expected << 4.0, 4.0,
       4.0, 4.0,
       4.0, 4.0,
       4.0, 4.0;
-  validate(equals(velocities, expected), velocities);
+  validate(isEqual(velocities, expected), velocities);
   expected << 4.0, 4.0,
       4.0, 4.0,
       4.0, 4.0,
       4.0, 4.0;
-  validate(equals(displDeltas, expected), displDeltas);
+  validate(isEqual(displDeltas, expected), displDeltas);
   expected << 0.0, 4.0,
       0.0, 4.0,
       0.0, 4.0,
       0.0, 4.0;
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << -1.0, 0.0,
       -1.0, 0.0,
@@ -139,22 +140,22 @@ void Tests::test2D()
       4.0, 0.0,
       4.0, 0.0,
       4.0, 0.0;
-  validate(equals(displacements, expected), displacements);
+  validate(isEqual(displacements, expected), displacements);
   expected << 0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0;
-  validate(equals(velocities, expected), velocities);
+  validate(isEqual(velocities, expected), velocities);
   expected << 0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0;
-  validate(equals(displDeltas, expected), displDeltas);
+  validate(isEqual(displDeltas, expected), displDeltas);
   expected << -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0;
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
   structure.iterate(dt);
@@ -163,22 +164,22 @@ void Tests::test2D()
       0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0;
-  validate(equals(displacements, expected), displacements);
+  validate(isEqual(displacements, expected), displacements);
   expected << -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0;
-  validate(equals(velocities, expected), velocities);
+  validate(isEqual(velocities, expected), velocities);
   expected << -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0;
-  validate(equals(displDeltas, expected), displDeltas);
+  validate(isEqual(displDeltas, expected), displDeltas);
   expected << -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0,
       -4.0, 0.0;
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
 
@@ -193,22 +194,22 @@ void Tests::test2D()
       0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0;
-  validate(equals(displacements, expected), displacements);
+  validate(isEqual(displacements, expected), displacements);
   expected << 0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0;
-  validate(equals(velocities, expected), velocities);
+  validate(isEqual(velocities, expected), velocities);
   expected << 0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0,
       0.0, 0.0;
-  validate(equals(displDeltas, expected), displDeltas);
+  validate(isEqual(displDeltas, expected), displDeltas);
   expected << 4.0, 0.0,
       4.0, 0.0,
       4.0, 0.0,
       4.0, 0.0;
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   structure.timestep(dt);
 
@@ -224,7 +225,7 @@ void Tests::test2D()
       rot, rot,
       -rot, rot,
       -rot, -rot;
-  validate(equals(displacements, expected), displacements);
+  validate(isEqual(displacements, expected), displacements);
 
   STRUCTURE_DEBUG("  ...done test2D()");
 }
@@ -278,24 +279,24 @@ void Tests::test3D()
   validate(velDeltas.size() == 24, velDeltas.size());
 
   expected.setConstant(0.0);
-  validate(equals(forces, expected), forces);
-  validate(equals(displacements, expected), displacements);
-  validate(equals(velocities, expected), velocities);
-  validate(equals(displDeltas, expected), displDeltas);
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(forces, expected), forces);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   validate(structure.getCenterOfGravity().size() == 3, structure.getCenterOfGravity().size());
-  validate(equals(structure.getCenterOfGravity(), Vector3d(0.5, 0.5, 0.5)),
+  validate(isEqual(structure.getCenterOfGravity(), Vector3d(0.5, 0.5, 0.5)),
            structure.getCenterOfGravity());
 
   double dt = 0.0;
   structure.iterate(dt);
 
-  validate(equals(forces, expected), forces);
-  validate(equals(displacements, expected), displacements);
-  validate(equals(velocities, expected), velocities);
-  validate(equals(displDeltas, expected), displDeltas);
-  validate(equals(velDeltas, expected), velDeltas);
+  validate(isEqual(forces, expected), forces);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << 0.0, 0.0, 1.0,
       0.0, 0.0, 1.0,
@@ -316,8 +317,8 @@ void Tests::test3D()
       0.0, 0.0, 32.0,
       0.0, 0.0, 32.0,
       0.0, 0.0, 32.0;
-  validate(equals(displacements, expected, eps), displacements);
-  validate(equals(displDeltas, expected, eps), displDeltas);
+  validate(isEqual(displacements, expected, eps), displacements);
+  validate(isEqual(displDeltas, expected, eps), displDeltas);
   expected << 0.0, 0.0, 16.0,
       0.0, 0.0, 16.0,
       0.0, 0.0, 16.0,
@@ -326,8 +327,8 @@ void Tests::test3D()
       0.0, 0.0, 16.0,
       0.0, 0.0, 16.0,
       0.0, 0.0, 16.0;
-  validate(equals(velocities, expected, eps), velocities);
-  validate(equals(velDeltas, expected, eps), velDeltas);
+  validate(isEqual(velocities, expected, eps), velocities);
+  validate(isEqual(velDeltas, expected, eps), velDeltas);
 
   forces << 0.0, 1.0, 0.0,
       0.0, 1.0, 0.0,
@@ -348,10 +349,10 @@ void Tests::test3D()
       0.0, 8.0, 0.0,
       0.0, 8.0, 0.0,
       0.0, 8.0, 0.0;
-  validate(equals(displacements, expected, eps), displacements);
-  validate(equals(displDeltas, expected, eps), displDeltas);
-  validate(equals(velocities, expected, eps), velocities);
-  validate(equals(velDeltas, expected, eps), velDeltas);
+  validate(isEqual(displacements, expected, eps), displacements);
+  validate(isEqual(displDeltas, expected, eps), displDeltas);
+  validate(isEqual(velocities, expected, eps), velocities);
+  validate(isEqual(velDeltas, expected, eps), velDeltas);
 
   forces << 1.0, 0.0, 0.0,
       1.0, 0.0, 0.0,
@@ -372,10 +373,10 @@ void Tests::test3D()
       8.0, 0.0, 0.0,
       8.0, 0.0, 0.0,
       8.0, 0.0, 0.0;
-  validate(equals(displacements, expected, eps), displacements);
-  validate(equals(displDeltas, expected, eps), displDeltas);
-  validate(equals(velocities, expected, eps), velocities);
-  validate(equals(velDeltas, expected, eps), velDeltas);
+  validate(isEqual(displacements, expected, eps), displacements);
+  validate(isEqual(displDeltas, expected, eps), displDeltas);
+  validate(isEqual(velocities, expected, eps), velocities);
+  validate(isEqual(velDeltas, expected, eps), velDeltas);
 
   forces << 1.0, 0.0, 0.0,
       1.0, 0.0, 0.0,
@@ -396,7 +397,7 @@ void Tests::test3D()
       -2.0, 0.0, 2.0,
       -2.0, 0.0, 2.0,
       -2.0, 0.0, -2.0;
-  validate(equals(displacements, expected, eps), displacements);
+  validate(isEqual(displacements, expected, eps), displacements);
 
   forces << 0.0, 1.0, 0.0,
       0.0, 1.0, 0.0,
@@ -417,7 +418,7 @@ void Tests::test3D()
       0.0, -2.0, -2.0,
       0.0, -2.0, 2.0,
       0.0, -2.0, 2.0;
-  validate(equals(displacements, expected, eps), displacements);
+  validate(isEqual(displacements, expected, eps), displacements);
 
   forces << 0.0, 0.0, 1.0,
       0.0, 0.0, -1.0,
@@ -438,7 +439,7 @@ void Tests::test3D()
       2.0, 0.0, -2.0,
       2.0, 0.0, -2.0,
       2.0, 0.0, 2.0;
-  validate(equals(displacements, expected, eps), displacements);
+  validate(isEqual(displacements, expected, eps), displacements);
 
   STRUCTURE_DEBUG("  ...done test3D()");
 }

--- a/Tests.cpp
+++ b/Tests.cpp
@@ -240,7 +240,6 @@ void Tests::test3D()
   Vector3d        gravity  = Vector3d::Zero();
   VectorXd        vertices = VectorXd::Zero(8 * dim);            // Cube vertex coordinates
   Eigen::VectorXi faces    = Eigen::VectorXi::Zero(6 * 2 * dim); // Triangle vertex indices
-  double          eps      = 1e-13;
 
   vertices << 0.0, 0.0, 0.0, // 0
       1.0, 0.0, 0.0,         // 1
@@ -317,8 +316,8 @@ void Tests::test3D()
       0.0, 0.0, 32.0,
       0.0, 0.0, 32.0,
       0.0, 0.0, 32.0;
-  validate(isEqual(displacements, expected, eps), displacements);
-  validate(isEqual(displDeltas, expected, eps), displDeltas);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(displDeltas, expected), displDeltas);
   expected << 0.0, 0.0, 16.0,
       0.0, 0.0, 16.0,
       0.0, 0.0, 16.0,
@@ -327,8 +326,8 @@ void Tests::test3D()
       0.0, 0.0, 16.0,
       0.0, 0.0, 16.0,
       0.0, 0.0, 16.0;
-  validate(isEqual(velocities, expected, eps), velocities);
-  validate(isEqual(velDeltas, expected, eps), velDeltas);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << 0.0, 1.0, 0.0,
       0.0, 1.0, 0.0,
@@ -349,10 +348,10 @@ void Tests::test3D()
       0.0, 8.0, 0.0,
       0.0, 8.0, 0.0,
       0.0, 8.0, 0.0;
-  validate(isEqual(displacements, expected, eps), displacements);
-  validate(isEqual(displDeltas, expected, eps), displDeltas);
-  validate(isEqual(velocities, expected, eps), velocities);
-  validate(isEqual(velDeltas, expected, eps), velDeltas);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << 1.0, 0.0, 0.0,
       1.0, 0.0, 0.0,
@@ -373,10 +372,10 @@ void Tests::test3D()
       8.0, 0.0, 0.0,
       8.0, 0.0, 0.0,
       8.0, 0.0, 0.0;
-  validate(isEqual(displacements, expected, eps), displacements);
-  validate(isEqual(displDeltas, expected, eps), displDeltas);
-  validate(isEqual(velocities, expected, eps), velocities);
-  validate(isEqual(velDeltas, expected, eps), velDeltas);
+  validate(isEqual(displacements, expected), displacements);
+  validate(isEqual(displDeltas, expected), displDeltas);
+  validate(isEqual(velocities, expected), velocities);
+  validate(isEqual(velDeltas, expected), velDeltas);
 
   forces << 1.0, 0.0, 0.0,
       1.0, 0.0, 0.0,
@@ -397,7 +396,7 @@ void Tests::test3D()
       -2.0, 0.0, 2.0,
       -2.0, 0.0, 2.0,
       -2.0, 0.0, -2.0;
-  validate(isEqual(displacements, expected, eps), displacements);
+  validate(isEqual(displacements, expected), displacements);
 
   forces << 0.0, 1.0, 0.0,
       0.0, 1.0, 0.0,
@@ -418,7 +417,7 @@ void Tests::test3D()
       0.0, -2.0, -2.0,
       0.0, -2.0, 2.0,
       0.0, -2.0, 2.0;
-  validate(isEqual(displacements, expected, eps), displacements);
+  validate(isEqual(displacements, expected), displacements);
 
   forces << 0.0, 0.0, 1.0,
       0.0, 0.0, -1.0,
@@ -439,7 +438,7 @@ void Tests::test3D()
       2.0, 0.0, -2.0,
       2.0, 0.0, -2.0,
       2.0, 0.0, 2.0;
-  validate(isEqual(displacements, expected, eps), displacements);
+  validate(isEqual(displacements, expected), displacements);
 
   STRUCTURE_DEBUG("  ...done test3D()");
 }

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -1,0 +1,115 @@
+# - Try to find Eigen3 lib
+#
+# This module supports requiring a minimum version, e.g. you can do
+#   find_package(Eigen3 3.1.2)
+# to require version 3.1.2 or newer of Eigen3.
+#
+# Once done this will define
+#
+#  EIGEN3_FOUND - system has eigen lib with correct version
+#  EIGEN3_INCLUDE_DIR - the eigen include directory
+#  EIGEN3_VERSION - eigen version
+#
+# and the following imported target:
+#
+#  Eigen3::Eigen - The header-only Eigen library
+#
+# This module reads hints about search locations from 
+# the following environment variables:
+#
+# Eigen3_ROOT
+# EIGEN3_ROOT
+# EIGEN3_ROOT_DIR
+#
+# This module reads reads further hints about search locations from 
+# the following CMake variables:
+#
+# Eigen3_ROOT
+#
+
+# Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
+# Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
+# Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
+# Redistribution and use is allowed according to the terms of the 2-clause BSD license.
+
+if(NOT Eigen3_FIND_VERSION)
+  if(NOT Eigen3_FIND_VERSION_MAJOR)
+    set(Eigen3_FIND_VERSION_MAJOR 2)
+  endif(NOT Eigen3_FIND_VERSION_MAJOR)
+  if(NOT Eigen3_FIND_VERSION_MINOR)
+    set(Eigen3_FIND_VERSION_MINOR 91)
+  endif(NOT Eigen3_FIND_VERSION_MINOR)
+  if(NOT Eigen3_FIND_VERSION_PATCH)
+    set(Eigen3_FIND_VERSION_PATCH 0)
+  endif(NOT Eigen3_FIND_VERSION_PATCH)
+
+  set(Eigen3_FIND_VERSION "${Eigen3_FIND_VERSION_MAJOR}.${Eigen3_FIND_VERSION_MINOR}.${Eigen3_FIND_VERSION_PATCH}")
+endif(NOT Eigen3_FIND_VERSION)
+
+macro(_eigen3_check_version)
+  file(READ "${EIGEN3_INCLUDE_DIR}/Eigen/src/Core/util/Macros.h" _eigen3_version_header)
+
+  string(REGEX MATCH "define[ \t]+EIGEN_WORLD_VERSION[ \t]+([0-9]+)" _eigen3_world_version_match "${_eigen3_version_header}")
+  set(EIGEN3_WORLD_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MAJOR_VERSION[ \t]+([0-9]+)" _eigen3_major_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MAJOR_VERSION "${CMAKE_MATCH_1}")
+  string(REGEX MATCH "define[ \t]+EIGEN_MINOR_VERSION[ \t]+([0-9]+)" _eigen3_minor_version_match "${_eigen3_version_header}")
+  set(EIGEN3_MINOR_VERSION "${CMAKE_MATCH_1}")
+
+  set(EIGEN3_VERSION ${EIGEN3_WORLD_VERSION}.${EIGEN3_MAJOR_VERSION}.${EIGEN3_MINOR_VERSION})
+  if(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK FALSE)
+  else(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+    set(EIGEN3_VERSION_OK TRUE)
+  endif(${EIGEN3_VERSION} VERSION_LESS ${Eigen3_FIND_VERSION})
+
+  if(NOT EIGEN3_VERSION_OK)
+
+    message(STATUS "Eigen3 version ${EIGEN3_VERSION} found in ${EIGEN3_INCLUDE_DIR}, "
+                   "but at least version ${Eigen3_FIND_VERSION} is required")
+  endif(NOT EIGEN3_VERSION_OK)
+endmacro(_eigen3_check_version)
+
+if (EIGEN3_INCLUDE_DIR)
+
+  # in cache already
+  _eigen3_check_version()
+  set(EIGEN3_FOUND ${EIGEN3_VERSION_OK})
+
+else (EIGEN3_INCLUDE_DIR)
+  
+  # search first if an Eigen3Config.cmake is available in the system,
+  # if successful this would set EIGEN3_INCLUDE_DIR and the rest of
+  # the script will work as usual
+  find_package(Eigen3 ${Eigen3_FIND_VERSION} NO_MODULE QUIET)
+
+  if(NOT EIGEN3_INCLUDE_DIR)
+    find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+        HINTS
+        ${Eigen3_ROOT}
+        ENV Eigen3_ROOT 
+        ENV EIGEN3_ROOT 
+        ENV EIGEN3_ROOT_DIR
+        PATHS
+        ${CMAKE_INSTALL_PREFIX}/include
+        ${KDE4_INCLUDE_DIR}
+        PATH_SUFFIXES eigen3 eigen
+      )
+  endif(NOT EIGEN3_INCLUDE_DIR)
+
+  if(EIGEN3_INCLUDE_DIR)
+    _eigen3_check_version()
+  endif(EIGEN3_INCLUDE_DIR)
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(Eigen3 DEFAULT_MSG EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK)
+
+  mark_as_advanced(EIGEN3_INCLUDE_DIR)
+
+endif(EIGEN3_INCLUDE_DIR)
+
+if(EIGEN3_FOUND AND NOT TARGET Eigen3::Eigen)
+  add_library(Eigen3::Eigen INTERFACE IMPORTED)
+  set_target_properties(Eigen3::Eigen PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${EIGEN3_INCLUDE_DIR}")
+endif()

--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 #include <sstream>
+#include <Eigen/Core>
+
 #include "Globals.hpp"
 #include "Structure0815.hpp"
 #include "Tests.hpp"
 #include "precice/SolverInterface.hpp"
-#include "utils/Dimensions.hpp"
-#include "utils/Globals.hpp"
 
 using Eigen::Vector2d;
 using Eigen::VectorXd;

--- a/math.hpp
+++ b/math.hpp
@@ -1,0 +1,22 @@
+#ifndef MATH_HPP
+#define MATH_HPP
+
+#include <Eigen/Core>
+
+namespace math {
+
+constexpr double PRECISION = 1.0e-14;
+
+template <typename DerivedLHS, typename DerivedRHS>
+bool isEqual(const Eigen::DenseBase<DerivedLHS> &lhs,
+             const Eigen::DenseBase<DerivedRHS> &rhs) {
+  return lhs.isapprox(lhs, rhs, PRECISION);
+}
+
+template <typename Derived>
+bool isZero(const Eigen::DenseBase<Derived> &val) {
+  return val.isZero(PRECISION);
+}
+
+} // namespace math
+#endif /* end of include guard */

--- a/math.hpp
+++ b/math.hpp
@@ -2,6 +2,7 @@
 #define MATH_HPP
 
 #include <Eigen/Core>
+#include <cassert>
 
 namespace math {
 
@@ -10,12 +11,34 @@ constexpr double PRECISION = 1.0e-14;
 template <typename DerivedLHS, typename DerivedRHS>
 bool isEqual(const Eigen::DenseBase<DerivedLHS> &lhs,
              const Eigen::DenseBase<DerivedRHS> &rhs) {
-  return lhs.isapprox(lhs, rhs, PRECISION);
+  return lhs.isApprox(rhs, PRECISION);
 }
 
-template <typename Derived>
-bool isZero(const Eigen::DenseBase<Derived> &val) {
-  return val.isZero(PRECISION);
+inline bool isZero(double val) {
+  return std::abs(val) < PRECISION;
+}
+
+inline double triangleArea(
+    const Eigen::VectorXd &a,
+    const Eigen::VectorXd &b,
+    const Eigen::VectorXd &c)
+{
+  assert(a.size() == b.size());
+  assert(b.size() == c.size());
+  if (a.size() == 2) {
+    Eigen::Vector2d A = b;
+    A -= a;
+    Eigen::Vector2d B = c;
+    B -= a;
+    return 0.5 * (A(0) * B(1) - A(1) * B(0));
+  } else {
+    assert(a.size() == 3);
+    Eigen::Vector3d A = b;
+    A -= a;
+    Eigen::Vector3d B = c;
+    B -= a;
+    return 0.5 * A.cross(B).norm();
+  }
 }
 
 } // namespace math


### PR DESCRIPTION
This PR removes preCICE internals from the solver and replaces them if necessary.
The solver now needs to be ported to preCICE 2.0.

Closes #6 